### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/ISBN/ISBN.csproj
+++ b/src/ISBN/ISBN.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GroupsGenerator\GroupsGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" Pack="false" />
-    <ProjectReference Include="..\ISBN.CodeAnalysis\ISBN.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />
+    <!--<ProjectReference Include="..\ISBN.CodeAnalysis\ISBN.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />-->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink